### PR TITLE
add IOHK and RChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ A curated list of awesome Applied Category Theory resources.
 
 * [Conexus](https://conexus.ai/) - developing [CQL](https://www.categoricaldata.net/), a tool for data migrations
 * [Statebox](https://statebox.org/) - building a formally verified process language using robust mathematical principles to prevent errors, allow compositionality and ensure termination
+* [IOHK](https://iohk.io/en/research/library/) - builds cryptocurrencies and blockchain solutions, based on peer reviewed papers; formally verified specifications in [Agda](https://github.com/input-output-hk/plutus/tree/master/metatheory), [Coq](https://github.com/input-output-hk?language=coq) and [k-framework](https://testnet.iohkdev.io/iele/about/formal-verification/)
+* [RChain](https://github.com/rchain/) - blockchain ecosystem it's foundational language - Rholang is implementation of [rho-calculus](http://rho.loria.fr/index.html) wih deep roots in [higher category theory](https://arxiv.org/abs/1504.04311) and [enriched Lawvere theories](https://arxiv.org/abs/1704.03080)
 
 ### Conferences
 


### PR DESCRIPTION
Before I found out about Statebox, I thought IOHK and RChain as the only companies that use mathematics including the fun one - Category Theory and formal verification in Agda) to develop software. To see why I thought so:
* for RChain at Greg Meredith publications: https://arxiv.org/search/cs?searchtype=author&query=Meredith%2C+L+G
* for IOHK: https://iohk.io/en/research/library/

Maybe you would like to have them mentioned too on your awesome wiki :)